### PR TITLE
Fix for infinite loop in inotify buffer parser.

### DIFF
--- a/job_archive.cpp
+++ b/job_archive.cpp
@@ -430,6 +430,8 @@ void do_inotify(const int& id, const string& watchDir, Queue<SlurmJobDirectory>*
  
         while ( i < length ) {
           struct inotify_event *event = ( struct inotify_event * ) &buffer[ i ];
+          i += EVENT_SIZE + event->len;
+
           if ( event->len ) {
             if ( event->mask & IN_CREATE && event->mask & IN_ISDIR) {
                 if (debug > 2) {
@@ -456,8 +458,6 @@ void do_inotify(const int& id, const string& watchDir, Queue<SlurmJobDirectory>*
                 if (debug > 2) cout << "do_inotify:" << id << " enqueue q-size: " << pqueue->getQueueSize() << endl;
 
             } // if ( event->mask & IN_CREATE && event->mask & IN_ISDIR)
-
-            i += EVENT_SIZE + event->len;
           } // if ( event->len )
         } // while
     } // while(1)


### PR DESCRIPTION
If an unexpected directory is seen then the parser would
log the directory information and then continue without
incrementing the cursor. This means that the parser will
sit in an infinite loop printing the same debug line if
a non-standard directory name is seen.

Also the parser would not increment the cursor if the event->len
was zero. This edge case is unlikely to happen, but is also
mitigated by this code change.