### PR TITLE
new setfacl() gives HPC-ITS-staff access to user archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,30 +22,25 @@ myjob is from #SBATCH --job-name=myjob
 
 ## Build Instructions
 
-In our environment we are using a default gcc 4.4.7 from Cent OS 6. Because of this older gcc version, which we chose not to upgrade to a newer version, then this does impact a few of the design strategies.
+In our environment we are using a default gcc 8.3.1 from Cent OS 8.
 
-To build, use this simple one liner:
-
- - g++ job_archive.cpp -o job_archive -std=c++0x -lpthread
-
-If you are running a newer version of gcc, then use an appropriate alternate, such as:
+To build, we used this simple one liner:
 
  - g++ job_archive.cpp -o job_archive -std=c++11 -lpthread
 
 ## Deployment Environment
 
-In our environment we use an init.d service configured with the following paths:
+In our environment we use a systemd service configured with the following paths:
 
  - run from: /etc/init.d/jobarchive-service-example
 
  - program binary run from: /usr/local/jobarchive/job_archive
-
- - internal logging at: /var/log/jobarchive/jobarchive.log
+ 
+The program writes logging information to STDOUT and so is accessible via
+/var/log/messages.
 
 The program writes to the local job archival directory is on the slurm controller host:
  - /var/slurm/jobscript_archive/
 
 Then a cron runs every 5 minutes to move all jobs to a common user accessable path:
  - /your-dir/jobscript_archive
-
-

--- a/jobarchive-service-example
+++ b/jobarchive-service-example
@@ -1,56 +1,13 @@
-#!/bin/sh
-### BEGIN INIT INFO
-# Provides:          jobarchive
-# Required-Start:    $local_fs $network $named $time $syslog
-# Required-Stop:     $local_fs $network $named $time $syslog
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
-# Description:       Slurm /var/slurm/jobscript_archive exporter
-### END INIT INFO
+[Unit]
+Description=Slurm Jobscript Archiver
+After=network.target remote-fs.target
 
-# normal w/o debug=0 logging
-PROG="/usr/local/jobarchive/job_archive"
-### NOTE: build from your local github subdirectory -> job_archive
-# with debug=1 logging auto turned on
-#PROG="/usr/local/jobarchive/job_archive -d"
+[Service]
+User=slurm
+ExecStart=/usr/local/jobarchive/jobarchive
+ExecReload=/bin/kill -HUP $MAINPID
+PIDFile=/var/run/jobarchive.pid
+KillMode=process
 
-PIDFILE=/var/run/jobarchive/jobarchive.pid
-LOGFILE=/var/log/jobarchive/jobarchive.log
-RUNAS=slurm
-
-start() {
-  if [ -f $PIDFILE ] && kill -0 $(cat $PIDFILE); then
-    echo 'Service already running' >&2
-    return 1
-  fi
-  echo 'Starting service…' >&2
-  local CMD="$PROG &>> \"$LOGFILE\" & echo \$!"
-  echo su - $RUNAS -c "$CMD"> "$PIDFILE"
-  su - $RUNAS -c "$CMD"> "$PIDFILE"
-  echo 'Service started' >&2
-}
-
-stop() {
-  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE"); then
-    echo 'Service not running' >&2
-    return 1
-  fi
-  echo 'Stopping service…' >&2
-  kill -15 $(cat "$PIDFILE") && rm -f "$PIDFILE"
-  echo 'Service stopped' >&2
-}
-
-case "$1" in
-  start)
-    start
-    ;;
-  stop)
-    stop
-    ;;
-  retart)
-    stop
-    start
-    ;;
-  *)
-    echo "Usage: $0 {start|stop|restart}"
-esac
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Code-wise only edited the setfacl() function within HelperFn.h to run a 2nd setfacl command. This code is already in-use and I did a test earlier on a local dir:

```
jfg95@wind:/scratch/jfg95/hpc/job_archive_edit $ getfacl ./testdir
# file: testdir
# owner: jfg95
# group: clusterstu
user::rwx
group::r-x
other::r-x

jfg95@wind:/scratch/jfg95/hpc/job_archive_edit $

jfg95@wind:/scratch/jfg95/hpc/job_archive_edit $ getfacl ./testdir
# file: testdir
# owner: jfg95
# group: clusterstu
user::rwx
group::r-x
other::r-x
default:user::rwx
default:user:jfg95:r-x
default:group::r-x
default:group:ITS-HPC-staff:r-x
default:mask::r-x
default:other::---

jfg95@wind:/scratch/jfg95/hpc/job_archive_edit $ 
```