### PR TITLE
Fix for file naming bug that was occurring ~1% of the time

### DIFF
--- a/HelperFn.h
+++ b/HelperFn.h
@@ -160,7 +160,7 @@ bool setfacl(string userid, string directory, vector<string> groups, bool debug)
     pclose(pipe);
 
     if (output.size() > 0) {
-        cout << "setfacl ERROR: " << &output[0] << endl;
+        cout << "setfacl ERROR: " << string(output.begin(), output.end()) << endl;
         return false;
     }
 
@@ -193,7 +193,7 @@ bool setfacl(string userid, string directory, vector<string> groups, bool debug)
       pclose(pipe);
 
       if (output.size() > 0) {
-        cout << "setfacl ERROR: " << &output[0] << endl;
+        cout << "setfacl ERROR: " << string(output.begin(), output.end()) << endl;
         return false;
       }
 

--- a/job_archive.cpp
+++ b/job_archive.cpp
@@ -1,4 +1,3 @@
-
 // to build (also see 00build.txt)
 /*
 g++ job_archive.cpp -o job_archive -std=c++0x -lpthread
@@ -125,24 +124,21 @@ struct ParseBuffer {
     string slurm_job_name;
     string slurm_submit_dir;
     // constructor
-    ParseBuffer(char *sentence) {
-      std::stringstream ss(sentence);
-      std::string line;
-      if (sentence != NULL) {
+    ParseBuffer(string sentence) {
+        std::stringstream ss(sentence);
+        std::string line;
         while(std::getline(ss,line,'\n')) {
-          size_t found=line.find('=');
-          if (found!=std::string::npos) {
-              string key = line.substr(0,found);
-              if (key == "USER") user = line.substr(found+1);
-              if (key == "SLURM_JOB_NAME") {
-                  slurm_job_name = line.substr(found+1);
-                  stripUnicode(slurm_job_name);
-              }
-              if (key == "SLURM_SUBMIT_DIR") slurm_submit_dir = line.substr(found+1);
-          }
-          //cout << line << endl;
+            size_t found=line.find('=');
+            if (found!=std::string::npos) {
+                string key = line.substr(0,found);
+                if (key == "USER") user = line.substr(found+1);
+                if (key == "SLURM_JOB_NAME") {
+                    slurm_job_name = line.substr(found+1);
+                    stripUnicode(slurm_job_name);
+                }
+                if (key == "SLURM_SUBMIT_DIR") slurm_submit_dir = line.substr(found+1);
+            }
         }
-      }
     }
     string altUser() {
       if (slurm_submit_dir.size() == 0) 
@@ -289,7 +285,7 @@ void do_processFiles( const int& id, const string& targDestPath1, Queue<SlurmJob
             if (buffer[i] == 0x00) buffer[i] = 0x0a;
         }
         // parse env for USER= SLURM_JOB_NAME= SLURM_SUBMIT_DIR=
-        ParseBuffer parse(&buffer[0]);
+        ParseBuffer parse(string(buffer.begin(), buffer.end()));
 
         if (parse.user.size() == 0) {
             if (debug > 1) {


### PR DESCRIPTION
This was a difficult bug to track down. But it was due to using the address of a vector<char> directly, which conceptually is fine since a C++ vector has objects stored sequentially just like arrays. But vector<char> is never null terminated automatically. We also used this construct in setfacl for a print statement but I believe setfacl never encountered an error so the code never ran.

Example Code:
```
#include <iostream>
#include <string>
#include <vector>
#include <stdlib.h>

using namespace std;

// need to test vector<char> -> string conversion

// good demo of what went wrong with the code too
// fix is very straight forward if using the string contructor with iterators

int main() {
    
    vector<char> buffer;

    srand(0);

    for(int i = 0; i < 100; i++) {
        buffer.push_back((char) (rand() % 26 + 97));
    }

    for(int i = 0; i < 100; i++) {
        buffer.pop_back();
    }
    
    buffer.push_back('h');
    buffer.push_back('e');
    buffer.push_back('l');
    buffer.push_back('l');
    buffer.push_back('o');

    string x = string(buffer.begin(), buffer.end());
    char* sentence = &buffer[0];
    string mystring = sentence;

    cout << x << endl;
    cout << buffer[5] << endl;
    cout << mystring << endl;
        
    return 0;
}

```

Output:
```
prompt-$ ./test
hello
b
hellobmqbhcdarzowkkyhiddqscdxrjmowfrxsjybldbefsarcbynecdyggxxpklorellnmpapqfwkhopkmcoqhnwnkuewhsqmgb
prompt-$ 
```

For the example pushed random chars and deleted since g++ may initialize array elements. Note that buffer.at(5) or another getter would throw a runtime error but accessing buffer[5] doesn't!